### PR TITLE
Add a "Limit Orders" section to the WooCommerce System Status Report

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,3 +18,8 @@ parameters:
 
 		# Apply filters can be called with any number of parameters.
 		- '#^Function apply_filters invoked with \d parameters, 2 required#'
+
+		# PHPStan doesn't care for variables being scoped into template includes.
+		-
+			message: '#Undefined variable: \$limiter$#'
+			path: %currentWorkingDirectory%/src/Views/

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -32,6 +32,7 @@ class Admin {
 		add_filter( 'woocommerce_get_settings_pages', [ $this, 'register_settings_page' ] );
 		add_filter( 'admin_notices', [ $this, 'admin_notice' ] );
 		add_filter( 'plugin_action_links_' . $basename, [ $this, 'action_links' ] );
+		add_action( 'woocommerce_system_status_report', [ $this, 'system_status_report' ] );
 	}
 
 	/**
@@ -90,11 +91,41 @@ class Admin {
 	}
 
 	/**
+	 * Render the system status report.
+	 */
+	public function system_status_report() {
+		$this->render_view( 'SystemStatusReport', [
+			'limiter' => $this->limiter,
+		] );
+	}
+
+	/**
 	 * Retrieve a link to the plugin's settings page.
 	 *
 	 * @return string An absolute URL to the settings page.
 	 */
 	protected function get_settings_url() {
 		return admin_url( 'admin.php?page=wc-settings&tab=limit-orders' );
+	}
+
+	/**
+	 * Render a view from within the Views/ directory.
+	 *
+	 * @param string $view The view name.
+	 * @param array  $vars Variables that should be exposed to the view.
+	 */
+	protected function render_view( $view, $vars = [] ) {
+		$template = sprintf( '%1$s/Views/%2$s.php', untrailingslashit( __DIR__ ), $view );
+
+		// We don't have enough of these yet to justify needing heavy error handling.
+		if ( ! file_exists( $template ) ) {
+			return;
+		}
+
+		// Extract the $vars so they're available within the template.
+		extract( $vars ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+
+		// Finally, include the template.
+		include $template;
 	}
 }

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -62,6 +62,15 @@ class OrderLimiter {
 	}
 
 	/**
+	 * Retrieve the interval setting.
+	 *
+	 * @return string The order limiter's interval.
+	 */
+	public function get_interval() {
+		return $this->get_setting( 'interval' );
+	}
+
+	/**
 	 * Retrieve the number of orders permitted per interval.
 	 *
 	 * @return int The maximum number of orders, or -1 if there is no limit.

--- a/src/Views/SystemStatusReport.php
+++ b/src/Views/SystemStatusReport.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Template for the WooCommerce system status report.
+ *
+ * @global \Nexcess\LimitOrders\OrderLimiter $limiter
+ */
+
+namespace Nexcess\LimitOrders\Views;
+
+?>
+
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+		<tr>
+			<th colspan="3" data-export-label="Limit Orders"><h2><?php esc_html_e( 'Limit Orders', 'limit-orders' ); ?><?php wp_kses_post( wc_help_tip( __( 'Current configuration for Limit Orders for WooCommerce.', 'limit-orders' ) ) ); ?></h2></th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-export-label="Enabled"><?php esc_html_e( 'Enabled', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'Is order limiting currently enabled on this store?', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo $limiter->is_enabled() ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Limit"><?php esc_html_e( 'Limit', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'How many orders may be accepted per interval?', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->get_limit() ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Submitted orders"><?php esc_html_e( 'Submitted Orders', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'How many orders have been submitted in the current interval?', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->regenerate_transient() ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Remaining orders"><?php esc_html_e( 'Remaining Orders', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'How many more orders will be accepted in the current interval?', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->get_remaining_orders() ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Interval"><?php esc_html_e( 'Interval', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'How often is the order limit reset?', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->get_interval() ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Interval start"><?php esc_html_e( 'Interval Start', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'When the current interval began.', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->get_interval_start()->format( 'c' ) ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Interval resets"><?php esc_html_e( 'Interval Resets', 'limit-orders' ); ?>:</td>
+			<td class="help"><?php wp_kses_post( wc_help_tip( __( 'When the next interval will begin.', 'limit-orders' ) ) ); ?></td>
+			<td><?php echo esc_html( $limiter->get_next_interval_start()->format( 'c' ) ); ?></td>
+		</tr>
+	</tbody>
+</table>
+</table>

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -28,6 +28,18 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @testdox get_interval() should return the interval setting
+	 */
+	public function get_interval_should_return_the_interval_setting() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'daily',
+		] );
+
+		$this->assertSame( 'daily', ( new OrderLimiter )->get_interval() );
+	}
+
+	/**
+	 * @test
 	 * @testdox get_limit() should return the set limit
 	 */
 	public function get_limit_should_return_the_set_limit() {


### PR DESCRIPTION
This PR adds a "Limit Orders" section to the WooCommerce System Status Report (WooCommerce &rsaquo; Status), with helpful debug information:

![Example output from the "Limit Orders" section of the WooCommerce System Status Report](https://user-images.githubusercontent.com/233836/79370077-0e129000-7f20-11ea-86ce-b569c8bd3c11.png)

This table will then also be parsed into the "Copy for support" version of the report:

```
### Limit Orders ###

Enabled: ✔
Limit: 100
Submitted orders: 0
Remaining orders: 100
Interval: weekly
Interval start: 2020-04-12T00:00:00+00:00
Interval resets: 2020-04-19T00:00:00+00:00
```

Fixes #7.