### PR TITLE
Override the default MySQL query limit when counting orders

### DIFF
--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -323,6 +323,7 @@ class OrderLimiter {
 			'type'         => wc_get_order_types( 'order-count' ),
 			'date_created' => '>=' . $this->get_interval_start()->getTimestamp(),
 			'return'       => 'ids',
+			'limit'        => max( $this->get_limit(), 1000 ),
 		] );
 
 		return count( $orders );

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -640,6 +640,21 @@ class OrderLimiterTest extends TestCase {
 	}
 
 	/**
+	 * @test
+	 */
+	public function count_qualifying_orders_should_not_limit_results() {
+		for ( $i = 0; $i < 24; $i++ ) {
+			$this->generate_order();
+		}
+
+		$instance = new OrderLimiter();
+		$method   = new \ReflectionMethod( $instance, 'count_qualifying_orders' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 24, $method->invoke( $instance ) );
+	}
+
+	/**
 	 * Create a new order by emulating the checkout process.
 	 */
 	protected function generate_order() {


### PR DESCRIPTION
`OrderLimiter::count_qualifying_orders()` relies on `wc_get_orders()`, which is several layers of abstraction over `WP_Query`.

Currently, if we analyze the query, it looks something like this:

```sql
SELECT wptests_posts.ID
FROM wptests_posts
WHERE 1=1
AND ( wptests_posts.post_date_gmt >= '2020-04-17 00:00:00' )
AND wptests_posts.post_type = 'shop_order'
AND (
    (
           wptests_posts.post_status = 'wc-pending'
        OR wptests_posts.post_status = 'wc-processing'
        OR wptests_posts.post_status = 'wc-on-hold'
        OR wptests_posts.post_status = 'wc-completed'
        OR wptests_posts.post_status = 'wc-cancelled'
        OR wptests_posts.post_status = 'wc-refunded'
        OR wptests_posts.post_status = 'wc-failed'
    )
)
ORDER BY wptests_posts.post_date DESC LIMIT 0, 10
```

Unfortunately, that last line is the problem: we're limiting the qualifying orders to 10, which is the default LIMIT value for `WP_Query`.

This PR overrides that default, setting it to either the limit set by the store _or_ `1000` (whichever is higher); this ensures that we're not running a `-1` limit on a store that could potentially have a very large threshold for orders (e.g. "oh, we only want to accept 1M orders/week").

Eventually, it may be worth rewriting this function to use an explicit SQL `COUNT(*)` query (thus eliminating limit concerns), but we want to ensure we do that in a way that maintains compatibility with WooCommerce's CRUD APIs.

This should also resolve the two open support tickets on WordPress.org:

1. https://wordpress.org/support/topic/limit-orders-did-not-work/
2. https://wordpress.org/support/topic/orders-have-exceeded-the-limit/