### PR TITLE
Version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Version 1.1.2] - 2020-04-17
+
+### Fixed
+
+* Override WordPress' default `LIMIT` on queries, which was preventing stores with limits > 10 from stopping orders ([#13]).
+
+
 ## [Version 1.1.1] — 2020-04-16
 
 ### Fixed
@@ -31,7 +38,9 @@ Initial plugin release.
 [Version 1.0.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.0.0
 [Version 1.1.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.0
 [Version 1.1.1]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.1
+[Version 1.1.2]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.2
 [#5]: https://github.com/nexcess/limit-orders/pull/5
 [#6]: https://github.com/nexcess/limit-orders/pull/6
 [#8]: https://github.com/nexcess/limit-orders/pull/8
 [#10]: https://github.com/nexcess/limit-orders/pull/10
+[#13]: https://github.com/nexcess/limit-orders/pull/13

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -6,7 +6,7 @@
  * Author URI:  https://nexcess.net
  * Text Domain: limit-orders
  * Domain Path: /languages
- * Version:     1.1.1
+ * Version:     1.1.2
  *
  * WC requires at least: 3.9
  * WC tested up to:      4.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: WooCommerce, ordering, limits, throttle
 Requires at least: 5.3
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: MIT
 License URI: https://github.com/nexcess/limit-orders/blob/master/LICENSE.txt
 
@@ -45,6 +45,9 @@ Yes, the order creation process through WP Admin is unaffected.
 
 For a complete list of changes, please [see the plugin's changelog on GitHub](https://github.com/nexcess/limit-orders/blob/master/CHANGELOG.md).
 
+= 1.1.2 (2020-04-17) =
+* Override WordPress' default "LIMIT" on queries, which was preventing stores with limits > 10 from stopping orders
+
 = 1.1.1 (2020-04-16) =
 * Prevent errors from occurring in WP Admin due to the customer-facing notice
 
@@ -55,6 +58,9 @@ For a complete list of changes, please [see the plugin's changelog on GitHub](ht
 Initial release of the plugin.
 
 == Upgrade Notice ==
+
+= 1.1.2 =
+Fixes error that was preventing order limiting from working on stores with limits higher than 10.
 
 = 1.1.1 =
 Fixes errors in WP Admin after a store's order limit has been reached.

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -323,6 +323,7 @@ class OrderLimiter {
 			'type'         => wc_get_order_types( 'order-count' ),
 			'date_created' => '>=' . $this->get_interval_start()->getTimestamp(),
 			'return'       => 'ids',
+			'limit'        => max( $this->get_limit(), 1000 ),
 		] );
 
 		return count( $orders );

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -640,6 +640,21 @@ class OrderLimiterTest extends TestCase {
 	}
 
 	/**
+	 * @test
+	 */
+	public function count_qualifying_orders_should_not_limit_results() {
+		for ( $i = 0; $i < 24; $i++ ) {
+			$this->generate_order();
+		}
+
+		$instance = new OrderLimiter();
+		$method   = new \ReflectionMethod( $instance, 'count_qualifying_orders' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 24, $method->invoke( $instance ) );
+	}
+
+	/**
 	 * Create a new order by emulating the checkout process.
 	 */
 	protected function generate_order() {


### PR DESCRIPTION
## Fixed

* Override WordPress' default `LIMIT` on queries, which was preventing stores with limits > 10 from stopping orders (#13).