### PR TITLE
Add "Hourly" as a default interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Added "hourly" as a default interval for stores ([#20]).
+* Added new placeholders to user-facing messaging ([#20]):
+	- `{current_interval:date}` (alias of `{current_interval}`)
+	- `{current_interval:time}`
+	- `{next_interval:date}` (alias of `{next_interval}`)
+	- `{next_interval:time}`
+
+### Updated
+
+* The settings screen will now show custom placeholders that have been registered via the "limit_orders_message_placeholders" filter ([#20]).
+
 ## [Version 1.1.2] - 2020-04-17
 
 ### Fixed
@@ -44,3 +59,4 @@ Initial plugin release.
 [#8]: https://github.com/nexcess/limit-orders/pull/8
 [#10]: https://github.com/nexcess/limit-orders/pull/10
 [#13]: https://github.com/nexcess/limit-orders/pull/13
+[#20]: https://github.com/nexcess/limit-orders/pull/20

--- a/README.md
+++ b/README.md
@@ -61,8 +61,16 @@ In any of these messages, you may also use the following variables:
 	<dd>The maximum number of orders accepted.</dd>
 	<dt>{current_interval}</dt>
 	<dd>The date the current interval started.</dd>
+	<dt>{current_interval:date}</dt>
+	<dd>An alias of <var>{current_interval}</var></dd>
+	<dt>{current_interval:time}</dt>
+	<dd>The time the current interval started.</dd>
 	<dt>{next_interval}</dt>
 	<dd>The date the next interval will begin (e.g. when orders will be accepted again).</dd>
+	<dt>{next_interval:date}</dt>
+	<dd>An alias of <var>{next_interval}</var></dd>
+	<dt>{next_interval:time}</dt>
+	<dd>The time the next interval will begin.</dd>
 </dl>
 
-Both `{current_interval}` and `{next_interval}` will be formatted [according to the "date format" setting for your store](https://wordpress.org/support/article/settings-general-screen/#date-format).
+Dates and times will be formatted [according to the "date format" and "time format" settings for your store](https://wordpress.org/support/article/settings-general-screen/#date-format), respectively.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Configuration for Limit Orders for WooCommerce is available through WooCommerce 
 	<dd>Customers will be unable to checkout after this number of orders are received.</dd>
 	<dd>Shop owners will still be able to create orders via WP Admin, even after the limit has been reached.</dd>
 	<dt>Interval</dt>
-	<dd>How often the limit is reset. By default, this can be "daily", "weekly", or "monthly".</dd>
+	<dd>How often the limit is reset. By default, this can be "hourly", daily", "weekly", or "monthly".</dd>
 	<dd>When choosing "weekly", the plugin will respect the value of <a href="https://wordpress.org/support/article/settings-general-screen/#week-starts-on">the store's "week starts on" setting</a>.</dd>
 </dl>
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -75,9 +75,10 @@ class Admin {
 		$next_interval = $this->limiter->get_next_interval_start();
 		$midnight      = current_datetime()->setTime( 24, 0, 0 );
 
+		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		if ( $next_interval == $midnight ) {
 			$next = _x( 'midnight', 'beginning of the next day/interval', 'limit-orders' );
-		} else if ( $next_interval < $midnight ) {
+		} elseif ( $next_interval < $midnight ) {
 			$next = $next_interval->format( get_option( 'time_format' ) );
 		} else {
 			$next = $next_interval->format( get_option( 'date_format' ) );

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -71,6 +71,18 @@ class Admin {
 			return;
 		}
 
+		// Change what text we show based on how far off it is.
+		$next_interval = $this->limiter->get_next_interval_start();
+		$midnight      = current_datetime()->setTime( 24, 0, 0 );
+
+		if ( $next_interval == $midnight ) {
+			$next = _x( 'midnight', 'beginning of the next day/interval', 'limit-orders' );
+		} else if ( $next_interval < $midnight ) {
+			$next = $next_interval->format( get_option( 'time_format' ) );
+		} else {
+			$next = $next_interval->format( get_option( 'date_format' ) );
+		}
+
 		echo '<div class="notice notice-warning"><p>';
 
 		if ( current_user_can( 'manage_options' ) ) {
@@ -78,13 +90,13 @@ class Admin {
 				/* Translators: %1$s is the settings page URL, %2$s is the reset date for order limiting. */
 				__( '<a href="%1$s">Based on your store\'s configuration</a>, new orders have been put on hold until %2$s.', 'limit-orders' ),
 				$this->get_settings_url(),
-				$this->limiter->get_next_interval_start()->format( get_option( 'date_format' ) )
+				$next
 			) );
 		} else {
 			echo esc_html( sprintf(
 				/* Translators: %1$s is the reset date for order limiting. */
 				__( 'Based on your store\'s configuration, new orders have been put on hold until %1$s.', 'limit-orders' ),
-				$this->limiter->get_next_interval_start()->format( get_option( 'date_format' ) )
+				$next
 			) );
 		}
 		echo '</p></div>';

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -161,6 +161,16 @@ class OrderLimiter {
 		$start    = $this->now;
 
 		switch ( $interval ) {
+			case 'hourly':
+				// Start at the top of the current hour.
+				$start = $start->setTime( (int) $start->format( 'h' ), 0, 0 );
+				break;
+
+			case 'daily':
+				// Start at midnight.
+				$start = $start->setTime( 0, 0, 0 );
+				break;
+
 			case 'weekly':
 				$start_of_week = (int) get_option( 'week_starts_on' );
 				$current_dow   = (int) $start->format( 'w' );
@@ -175,15 +185,15 @@ class OrderLimiter {
 				if ( 0 !== $diff ) {
 					$start = $start->sub( new \DateInterval( 'P' . $diff . 'D' ) );
 				}
+
+				$start = $start->setTime( 0, 0, 0 );
 				break;
 
 			case 'monthly':
-				$start = $start->setDate( (int) $start->format( 'Y' ), (int) $start->format( 'm' ), 1 );
+				$start = $start->setDate( (int) $start->format( 'Y' ), (int) $start->format( 'm' ), 1 )
+					->setTime( 0, 0, 0 );
 				break;
 		}
-
-		// Start everything at midnight.
-		$start = $start->setTime( 0, 0, 0 );
 
 		/**
 		 * Filter the DateTime object representing the start of the current interval.
@@ -205,6 +215,10 @@ class OrderLimiter {
 		$start    = clone $current;
 
 		switch ( $interval ) {
+			case 'hourly':
+				$start = $start->add( new \DateInterval( 'PT1H' ) );
+				break;
+
 			case 'daily':
 				$start = $start->add( new \DateInterval( 'P1D' ) );
 				break;

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -108,11 +108,34 @@ class OrderLimiter {
 		}
 
 		// Perform simple placeholder replacements.
+		$placeholders = $this->get_placeholders( $setting, $message );
+
+		return str_replace( array_keys( $placeholders ), array_values( $placeholders ), $message );
+	}
+
+	/**
+	 * Retrieve eligible placeholders for front-end messaging.
+	 *
+	 * Note that the parameters are only included for the sake of the filter.
+	 *
+	 * @param string $setting Optional. The current setting that's being retrieved. Default is empty.
+	 * @param string $message Optional. The current message being constructed. Default is empty.
+	 *
+	 * @return array An array of placeholder => replacements.
+	 */
+	public function get_placeholders( $setting = '', $message = '' ) {
 		$date_format  = get_option( 'date_format' );
+		$time_format  = get_option( 'time_format' );
+		$current      = $this->get_interval_start();
+		$next         = $this->get_next_interval_start();
 		$placeholders = [
-			'{current_interval}' => $this->get_interval_start()->format( $date_format ),
-			'{limit}'            => $this->get_limit(),
-			'{next_interval}'    => $this->get_next_interval_start()->format( $date_format ),
+			'{current_interval}'      => $current->format( $date_format ),
+			'{current_interval:date}' => $current->format( $date_format ),
+			'{current_interval:time}' => $current->format( $time_format ),
+			'{limit}'                 => $this->get_limit(),
+			'{next_interval}'         => $next->format( $date_format ),
+			'{next_interval:date}'    => $next->format( $date_format ),
+			'{next_interval:time}'    => $next->format( $time_format ),
 		];
 
 		/**
@@ -122,9 +145,7 @@ class OrderLimiter {
 		 * @param string $setting      The current message's setting key.
 		 * @param string $message      The current message to display.
 		 */
-		$placeholders = apply_filters( 'limit_orders_message_placeholders', $placeholders, $setting, $message );
-
-		return str_replace( array_keys( $placeholders ), array_values( $placeholders ), $message );
+		return apply_filters( 'limit_orders_message_placeholders', $placeholders, $setting, $message );
 	}
 
 	/**

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -58,7 +58,7 @@ class OrderLimiter {
 	 * @return bool
 	 */
 	public function is_enabled() {
-		return (bool) $this->get_setting( 'enabled' );
+		return (bool) $this->get_setting( 'enabled', false );
 	}
 
 	/**
@@ -67,7 +67,7 @@ class OrderLimiter {
 	 * @return string The order limiter's interval.
 	 */
 	public function get_interval() {
-		return $this->get_setting( 'interval' );
+		return $this->get_setting( 'interval', 'daily' );
 	}
 
 	/**
@@ -352,11 +352,11 @@ class OrderLimiter {
 	 *
 	 * @return mixed The value of $setting, or null $setting is undefined.
 	 */
-	protected function get_setting( string $setting ) {
+	protected function get_setting( string $setting, $default = null ) {
 		if ( null === $this->settings ) {
 			$this->settings = get_option( self::OPTION_KEY, [] );
 		}
 
-		return isset( $this->settings[ $setting ] ) ? $this->settings[ $setting ] : null;
+		return isset( $this->settings[ $setting ] ) ? $this->settings[ $setting ] : $default;
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -126,7 +126,7 @@ class Settings extends WC_Settings_Page {
 		global $wp_locale;
 
 		$intervals = [
-			'hourly'  => _x( 'Hourly (resets at the top of every hour)', 'order threshold interval', 'limit orders' ),
+			'hourly'  => _x( 'Hourly (resets at the top of every hour)', 'order threshold interval', 'limit-orders' ),
 			'daily'   => _x( 'Daily (resets every day)', 'order threshold interval', 'limit-orders' ),
 			'weekly'  => sprintf(
 				/* Translators: %1$s is the first day of the week, based on site configuration. */

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -35,6 +35,16 @@ class Settings extends WC_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings() {
+		$placeholders           = (array) $this->limiter->get_placeholders();
+		$available_placeholders = '';
+
+		// Build a list of available placeholders.
+		if ( ! empty( $placeholders ) ) {
+			$available_placeholders  = __( 'Available placeholders:', 'limit-orders' ) . ' <var>';
+			$available_placeholders .= implode( '</var>, <var>', array_keys( $placeholders ) );
+			$available_placeholders .= '</var>';
+		}
+
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, [
 			[
 				'id'   => 'limit-orders-general',
@@ -75,7 +85,7 @@ class Settings extends WC_Settings_Page {
 				'id'   => 'limit-orders-messaging',
 				'type' => 'title',
 				'name' => _x( 'Customer messaging', 'settings section title', 'limit-orders' ),
-				'desc' => '<p>' . __( 'Customize the messages shown to customers once ordering is disabled.', 'limit-orders' ) . '</p><p>' . __( 'Available placeholders: <var>{limit}</var>, <var>{current_interval}</var>, <var>{next_interval}</var>.', 'limit-orders' ) . '</p>',
+				'desc' => '<p>' . __( 'Customize the messages shown to customers once ordering is disabled.', 'limit-orders' ) . '</p>' . $available_placeholders ? '<p>' . $available_placeholders . '</p>' : '',
 			],
 			[
 				'id'       => OrderLimiter::OPTION_KEY . '[customer_notice]',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -116,6 +116,7 @@ class Settings extends WC_Settings_Page {
 		global $wp_locale;
 
 		$intervals = [
+			'hourly'  => _x( 'Hourly (resets at the top of every hour)', 'order threshold interval', 'limit orders' ),
 			'daily'   => _x( 'Daily (resets every day)', 'order threshold interval', 'limit-orders' ),
 			'weekly'  => sprintf(
 				/* Translators: %1$s is the first day of the week, based on site configuration. */

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -208,6 +208,26 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 */
+	public function get_interval_start_for_hourly() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now   = new \DateTimeImmutable( '2020-04-27 12:05:00', wp_timezone() );
+		$start = new \DateTimeImmutable( '2020-04-27 12:00:00', wp_timezone() );
+
+		$this->assertSame(
+			$start->format( 'r' ),
+			( new OrderLimiter( $now ) )->get_interval_start()->format( 'r' ),
+			'Hourly intervals should start at the top of the hour.'
+		);
+	}
+
+	/**
+	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_daily() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -328,6 +348,26 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 */
+	public function get_next_interval_start_for_hourly() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now  = new \DateTimeImmutable( '2020-04-27 12:05:00', wp_timezone() );
+		$next = new \DateTimeImmutable( '2020-04-27 13:00:00', wp_timezone() );
+
+		$this->assertSame(
+			$next->format( 'r' ),
+			( new OrderLimiter( $now ) )->get_next_interval_start()->format( 'r' ),
+			'The next hourly interval should begin at the top of the next hour.'
+		);
+	}
+
+	/**
+	 * @test
+	 * @group Intervals
 	 */
 	public function get_next_interval_start_for_daily() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -383,6 +423,26 @@ class OrderLimiterTest extends TestCase {
 			$next->format( 'r' ),
 			( new OrderLimiter( $now ) )->get_next_interval_start()->format( 'r' ),
 			'The next monthly interval should begin at midnight on April 1.'
+		);
+	}
+
+	/**
+	 * @test
+	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 */
+	public function get_seconds_until_next_interval_for_hourly() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now  = new \DateTimeImmutable( '2020-04-27 12:05:00', wp_timezone() );
+		$next = new \DateTimeImmutable( '2020-04-27 13:00:00', wp_timezone() );
+
+		$this->assertSame(
+			$next->getTimestamp() - $now->getTimestamp(),
+			( new OrderLimiter( $now ) )->get_seconds_until_next_interval(),
+			'It should return the number of seconds until the next hour begins.'
 		);
 	}
 

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -29,6 +29,7 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @testdox get_interval() should return the interval setting
+	 * @group Intervals
 	 */
 	public function get_interval_should_return_the_interval_setting() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -206,6 +207,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_daily() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -224,6 +226,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_weekly() {
 		update_option( 'week_starts_on', 1 );
@@ -244,6 +247,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_weekly_with_a_non_standard_day() {
 		update_option( 'week_starts_on', 6 );
@@ -264,6 +268,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_weekly_when_today_is_the_first_day_of_the_week() {
 		update_option( 'week_starts_on', 1 );
@@ -284,6 +289,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_for_monthly() {
 		$today = new \DateTimeImmutable( 'now', wp_timezone() );
@@ -301,6 +307,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_interval_start_should_be_idempotent() {
 		$now     = new \DateTimeImmutable( '00:00:00', wp_timezone() );
@@ -320,6 +327,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_next_interval_start_for_daily() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -339,6 +347,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_next_interval_start_for_weekly() {
 		update_option( 'week_starts_on', 1 );
@@ -359,6 +368,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_next_interval_start_for_monthly() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -378,6 +388,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_seconds_until_next_interval_for_daily() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -397,6 +408,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_seconds_until_next_interval_for_weekly() {
 		update_option( 'week_starts_on', 1 );
@@ -417,6 +429,7 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function get_seconds_until_next_interval_for_monthly() {
 		update_option( OrderLimiter::OPTION_KEY, [

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -33,9 +33,18 @@ class OrderLimiterTest extends TestCase {
 	 */
 	public function get_interval_should_return_the_interval_setting() {
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval' => 'daily',
+			'interval' => 'weekly',
 		] );
 
+		$this->assertSame( 'weekly', ( new OrderLimiter )->get_interval() );
+	}
+
+	/**
+	 * @test
+	 * @testdox get_interval() should default to "daily"
+	 * @group Intervals
+	 */
+	public function get_interval_should_default_to_daily() {
 		$this->assertSame( 'daily', ( new OrderLimiter )->get_interval() );
 	}
 

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -118,12 +118,15 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @testdox get_message() should replace the {current_interval} placeholder
+	 * @testWith ["{current_interval}"]
+	 *           ["{current_interval:date}"]
+	 * @group Placeholders
 	 */
-	public function get_message_should_replace_current_interval_placeholder() {
+	public function get_message_should_replace_current_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
 			'interval'        => 'weekly',
-			'customer_notice' => 'This started on {current_interval}',
+			'customer_notice' => "This started on {$placeholder}",
 		] );
 
 		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
@@ -137,7 +140,29 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @testdox get_message() should replace the {current_interval:time} placeholder
+	 * @group Placeholders
+	 */
+	public function get_message_should_replace_current_interval_time_placeholder() {
+		update_option( 'time_format', 'g:ia' );
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval'        => 'hourly',
+			'customer_notice' => "This started at {current_interval:time}",
+		] );
+
+		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$limiter = new OrderLimiter( $now );
+
+		$this->assertSame(
+			'This started at ' . $limiter->get_interval_start()->format( 'g:ia' ),
+			$limiter->get_message( 'customer_notice' )
+		);
+	}
+
+	/**
+	 * @test
 	 * @testdox get_message() should replace the {limit} placeholder
+	 * @group Placeholders
 	 */
 	public function get_message_should_replace_limit_placeholder() {
 		update_option( OrderLimiter::OPTION_KEY, [
@@ -155,12 +180,15 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @testdox get_message() should replace the {next_interval} placeholder
+	 * @testWith ["{next_interval}"]
+	 *           ["{next_interval:date}"]
+	 * @group Placeholders
 	 */
-	public function get_message_should_replace_next_interval_placeholder() {
+	public function get_message_should_replace_next_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
 			'interval'        => 'weekly',
-			'customer_notice' => 'Check back on {next_interval}',
+			'customer_notice' => "Check back on {$placeholder}",
 		] );
 
 		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
@@ -170,6 +198,87 @@ class OrderLimiterTest extends TestCase {
 			'Check back on ' . $limiter->get_next_interval_start()->format( 'F j, Y' ),
 			$limiter->get_message( 'customer_notice' )
 		);
+	}
+
+	/**
+	 * @test
+	 * @testdox get_message() should replace the {next_interval:time} placeholder
+	 * @group Placeholders
+	 */
+	public function get_message_should_replace_next_interval_time_placeholder() {
+		update_option( 'time_format', 'g:ia' );
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval'        => 'hourly',
+			'customer_notice' => "Check back at {next_interval:time}",
+		] );
+
+		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$limiter = new OrderLimiter( $now );
+
+		$this->assertSame(
+			'Check back at ' . $limiter->get_next_interval_start()->format( 'g:ia' ),
+			$limiter->get_message( 'customer_notice' )
+		);
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 */
+	public function get_placeholders_should_return_an_array_of_default_placeholders() {
+		update_option( 'date_format', 'F j, Y' );
+		update_option( 'time_format', 'g:ia' );
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now          = new \DateTimeImmutable( '2020-04-27 12:15:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-04-27 12:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-04-27 13:00:00', wp_timezone() );
+		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
+
+		$this->assertSame( $current->format( 'F j, Y' ), $placeholders['{current_interval}'] );
+		$this->assertSame( $current->format( 'F j, Y' ), $placeholders['{current_interval:date}'] );
+		$this->assertSame( $current->format( 'g:ia' ), $placeholders['{current_interval:time}'] );
+		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval}'] );
+		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval:date}'] );
+		$this->assertSame( $next->format( 'g:ia' ), $placeholders['{next_interval:time}'] );
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 */
+	public function time_placeholders_should_replace_00_with_midnight() {
+		$this->markTestIncomplete( 'https://github.com/nexcess/limit-orders/issues/21' );
+
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'daily',
+		] );
+
+		$now          = new \DateTimeImmutable( '2020-04-27 12:15:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
+		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
+
+		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{current_interval:time}'] );
+		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{next_interval:time}'] );
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 */
+	public function get_placeholders_should_filter_placeholders() {
+		add_filter( 'limit_orders_message_placeholders', function ( $placeholders ) {
+			$placeholders['{test}'] = 'Test value';
+
+			return $placeholders;
+		} );
+
+		$placeholders = ( new OrderLimiter() )->get_placeholders();
+
+		$this->assertSame( 'Test value', $placeholders['{test}'] );
 	}
 
 	/**

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -723,8 +723,15 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @ticket https://github.com/nexcess/limit-orders/pull/13
 	 */
 	public function count_qualifying_orders_should_not_limit_results() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'enabled'  => true,
+			'interval' => 'daily',
+			'limit'    => 100,
+		] );
+
 		for ( $i = 0; $i < 24; $i++ ) {
 			$this->generate_order();
 		}

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -31,6 +31,23 @@ class SettingsTest extends TestCase {
 	/**
 	 * @test
 	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 */
+	public function it_should_include_default_intervals() {
+		$method = new \ReflectionMethod( Settings::class, 'get_intervals' );
+		$method->setAccessible( true );
+
+		$intervals = $method->invoke( new Settings( new OrderLimiter() ) );
+
+		$this->assertArrayHasKey( 'daily', $intervals );
+		$this->assertArrayHasKey( 'weekly', $intervals );
+		$this->assertArrayHasKey( 'monthly', $intervals );
+		$this->assertArrayHasKey( 'hourly', $intervals, 'Hourly was added in https://github.com/nexcess/limit-orders/issues/18' );
+	}
+
+	/**
+	 * @test
+	 * @group Intervals
 	 */
 	public function available_intervals_should_be_filterable() {
 		$intervals = [

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -70,4 +70,23 @@ class SettingsTest extends TestCase {
 
 		$this->fail( 'Did not find setting with ID "'. OrderLimiter::OPTION_KEY . '[interval]".' );
 	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 */
+	public function available_placeholders_should_be_shown_in_the_messages_section() {
+		$limiter  = new OrderLimiter();
+		$sections = array_filter( ( new Settings( new OrderLimiter() ) )->get_settings(), function ( $section ) {
+			return 'limit-orders-messaging' === $section['id'] && 'title' === $section['type'];
+		} );
+
+		$this->assertCount( 1, $sections, 'Expected to see only one instance of "limit-orders-messaging".' );
+
+		$description = current( $sections )['desc'];
+
+		foreach ( $limiter->get_placeholders() as $placeholder => $value ) {
+			$this->assertContains( '<var>' . $placeholder . '</var>', $description );
+		}
+	}
 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -30,6 +30,7 @@ class SettingsTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
 	 */
 	public function available_intervals_should_be_filterable() {
 		$intervals = [


### PR DESCRIPTION
This PR adds support for "hourly" as a default interval, meaning the order limiting would reset at the top of every hour.

Since this change introduces sub-day resetting, I've also applied some updates to the messaging within WP Admin (e.g. "Based on your store's configuration, new orders have been put on hold until 4:00pm" instead of always defaulting to the date on which the next interval begins).

The customer-facing placeholders have also been updated, giving store owners the following options:
* `{current_interval}` (e.g. "April 27, 2020")
* `{current_interval:date}` (alias of `{current_interval}`)
* `{current_interval:time}`(e.g. "5:00pm")
* `{next_interval}` (e.g. "April 28, 2020")
* `{next_interval:date}` (alias of `{next_interval}`)
* `{next_interval:time}`(e.g. "6:00pm")
* `{limit}` (e.g. "100")

I've kept `{current_interval}` and `{next_interval}` for backwards-compatibility purposes.

Fixes #18.