### PR TITLE
Ensure hourly intervals are calculated using 24hr time

### DIFF
--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -184,7 +184,7 @@ class OrderLimiter {
 		switch ( $interval ) {
 			case 'hourly':
 				// Start at the top of the current hour.
-				$start = $start->setTime( (int) $start->format( 'h' ), 0, 0 );
+				$start = $start->setTime( (int) $start->format( 'G' ), 0, 0 );
 				break;
 
 			case 'daily':

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -345,6 +345,26 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @depends get_interval_start_for_hourly
+	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/24
+	 */
+	public function get_interval_start_should_use_24hr_time() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now   = new \DateTimeImmutable( '2020-04-27 18:05:00', wp_timezone() );
+		$start = new \DateTimeImmutable( '2020-04-27 18:00:00', wp_timezone() );
+
+		$this->assertSame(
+			$start->format( 'r' ),
+			( new OrderLimiter( $now ) )->get_interval_start()->format( 'r' )
+		);
+	}
+
+	/**
+	 * @test
 	 * @group Intervals
 	 */
 	public function get_interval_start_for_daily() {


### PR DESCRIPTION
We were accidentally using 'h' (12-hour time with leading zeroes) instead of 'G' (24-hour time without leading zeroes) when calling DateTime::format() to calculate the beginning of an hourly interval.

Fixes #24.