### PR TITLE
Add a new {timezone} placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Added "hourly" as a default interval for stores ([#20]).
-* Added new placeholders to user-facing messaging ([#20]):
+* Added new placeholders to user-facing messaging ([#20], [#26]):
 	- `{current_interval:date}` (alias of `{current_interval}`)
 	- `{current_interval:time}`
 	- `{next_interval:date}` (alias of `{next_interval}`)
 	- `{next_interval:time}`
+	- `{timezone}`
 * Added documentation for adding custom intervals, placeholders ([#23]).
 
 ### Updated
@@ -62,3 +63,4 @@ Initial plugin release.
 [#13]: https://github.com/nexcess/limit-orders/pull/13
 [#20]: https://github.com/nexcess/limit-orders/pull/20
 [#23]: https://github.com/nexcess/limit-orders/pull/23
+[#26]: https://github.com/nexcess/limit-orders/pull/26

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ In any of these messages, you may also use the following variables:
 	<dd>An alias of <var>{next_interval}</var></dd>
 	<dt>{next_interval:time}</dt>
 	<dd>The time the next interval will begin.</dd>
+	<dt>{timezone}</dt>
+	<dd>The store's timezone, e.g. "PST", "EDT", etc. This will automatically update based on Daylight Saving Time.</dd>
 </dl>
 
 Dates and times will be formatted [according to the "date format" and "time format" settings for your store](https://wordpress.org/support/article/settings-general-screen/#date-format), respectively.

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -136,6 +136,7 @@ class OrderLimiter {
 			'{next_interval}'         => $next->format( $date_format ),
 			'{next_interval:date}'    => $next->format( $date_format ),
 			'{next_interval:time}'    => $next->format( $time_format ),
+			'{timezone}'              => $next->format( 'T' ),
 		];
 
 		/**

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -224,6 +224,8 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @group Placeholders
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 * @ticket https://github.com/nexcess/limit-orders/issues/22
 	 */
 	public function get_placeholders_should_return_an_array_of_default_placeholders() {
 		update_option( 'date_format', 'F j, Y' );
@@ -243,6 +245,7 @@ class OrderLimiterTest extends TestCase {
 		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval}'] );
 		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval:date}'] );
 		$this->assertSame( $next->format( 'g:ia' ), $placeholders['{next_interval:time}'] );
+		$this->assertSame( $next->format( 'T' ), $placeholders['{timezone}'] );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a `{timezone}` placeholder, which works by calling `$next_interval_start->format('T')`, giving us the abbreviated version (e.g. "EST", "MDT", etc.) while also accounting for daylight saving time.

For future reference, we're using the *next* interval's start time as this placeholder is more likely to be used for when orders will be accepted again rather than when the current interval started. This avoids embarassing situations like "Please check back on `$date` at `$time` EST" when `$date` is in EDT.

Fixes #22.