### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Added "hourly" as a default interval for stores ([#20]).
+* Added new placeholders to user-facing messaging ([#20]):
+	- `{current_interval:date}` (alias of `{current_interval}`)
+	- `{current_interval:time}`
+	- `{next_interval:date}` (alias of `{next_interval}`)
+	- `{next_interval:time}`
+
+### Updated
+
+* The settings screen will now show custom placeholders that have been registered via the "limit_orders_message_placeholders" filter ([#20]).
+
 ## [Version 1.1.2] - 2020-04-17
 
 ### Fixed
@@ -44,3 +59,4 @@ Initial plugin release.
 [#8]: https://github.com/nexcess/limit-orders/pull/8
 [#10]: https://github.com/nexcess/limit-orders/pull/10
 [#13]: https://github.com/nexcess/limit-orders/pull/13
+[#20]: https://github.com/nexcess/limit-orders/pull/20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Version 1.2.0] — 2020-04-27
 
 ### Added
 
@@ -56,6 +56,7 @@ Initial plugin release.
 [Version 1.1.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.0
 [Version 1.1.1]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.1
 [Version 1.1.2]: https://github.com/nexcess/limit-orders/releases/tag/v1.1.2
+[Version 1.2.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.2.0
 [#5]: https://github.com/nexcess/limit-orders/pull/5
 [#6]: https://github.com/nexcess/limit-orders/pull/6
 [#8]: https://github.com/nexcess/limit-orders/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Added "hourly" as a default interval for stores ([#20]).
-* Added new placeholders to user-facing messaging ([#20]):
+* Added new placeholders to user-facing messaging ([#20], [#26]):
 	- `{current_interval:date}` (alias of `{current_interval}`)
 	- `{current_interval:time}`
 	- `{next_interval:date}` (alias of `{next_interval}`)
 	- `{next_interval:time}`
+	- `{timezone}`
 * Added documentation for adding custom intervals, placeholders ([#23]).
 
 ### Updated
@@ -62,3 +63,4 @@ Initial plugin release.
 [#13]: https://github.com/nexcess/limit-orders/pull/13
 [#20]: https://github.com/nexcess/limit-orders/pull/20
 [#23]: https://github.com/nexcess/limit-orders/pull/23
+[#26]: https://github.com/nexcess/limit-orders/pull/26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 	- `{current_interval:time}`
 	- `{next_interval:date}` (alias of `{next_interval}`)
 	- `{next_interval:time}`
+* Added documentation for adding custom intervals, placeholders ([#23]).
 
 ### Updated
 
@@ -60,3 +61,4 @@ Initial plugin release.
 [#10]: https://github.com/nexcess/limit-orders/pull/10
 [#13]: https://github.com/nexcess/limit-orders/pull/13
 [#20]: https://github.com/nexcess/limit-orders/pull/20
+[#23]: https://github.com/nexcess/limit-orders/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Updated
 
 * The settings screen will now show custom placeholders that have been registered via the "limit_orders_message_placeholders" filter ([#20]).
+* Improve autoloader performance and remove type-hint from PSR-4 autoloader ([#17]).
 
 ## [Version 1.1.2] - 2020-04-17
 
@@ -62,6 +63,7 @@ Initial plugin release.
 [#8]: https://github.com/nexcess/limit-orders/pull/8
 [#10]: https://github.com/nexcess/limit-orders/pull/10
 [#13]: https://github.com/nexcess/limit-orders/pull/13
+[#17]: https://github.com/nexcess/limit-orders/pull/17
 [#20]: https://github.com/nexcess/limit-orders/pull/20
 [#23]: https://github.com/nexcess/limit-orders/pull/23
 [#26]: https://github.com/nexcess/limit-orders/pull/26

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Configuration for Limit Orders for WooCommerce is available through WooCommerce 
 	<dd>Customers will be unable to checkout after this number of orders are received.</dd>
 	<dd>Shop owners will still be able to create orders via WP Admin, even after the limit has been reached.</dd>
 	<dt>Interval</dt>
-	<dd>How often the limit is reset. By default, this can be "daily", "weekly", or "monthly".</dd>
+	<dd>How often the limit is reset. By default, this can be "hourly", daily", "weekly", or "monthly".</dd>
 	<dd>When choosing "weekly", the plugin will respect the value of <a href="https://wordpress.org/support/article/settings-general-screen/#week-starts-on">the store's "week starts on" setting</a>.</dd>
 </dl>
 
@@ -61,8 +61,16 @@ In any of these messages, you may also use the following variables:
 	<dd>The maximum number of orders accepted.</dd>
 	<dt>{current_interval}</dt>
 	<dd>The date the current interval started.</dd>
+	<dt>{current_interval:date}</dt>
+	<dd>An alias of <var>{current_interval}</var></dd>
+	<dt>{current_interval:time}</dt>
+	<dd>The time the current interval started.</dd>
 	<dt>{next_interval}</dt>
 	<dd>The date the next interval will begin (e.g. when orders will be accepted again).</dd>
+	<dt>{next_interval:date}</dt>
+	<dd>An alias of <var>{next_interval}</var></dd>
+	<dt>{next_interval:time}</dt>
+	<dd>The time the next interval will begin.</dd>
 </dl>
 
-Both `{current_interval}` and `{next_interval}` will be formatted [according to the "date format" setting for your store](https://wordpress.org/support/article/settings-general-screen/#date-format).
+Dates and times will be formatted [according to the "date format" and "time format" settings for your store](https://wordpress.org/support/article/settings-general-screen/#date-format), respectively.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ In any of these messages, you may also use the following variables:
 	<dd>An alias of <var>{next_interval}</var></dd>
 	<dt>{next_interval:time}</dt>
 	<dd>The time the next interval will begin.</dd>
+	<dt>{timezone}</dt>
+	<dd>The store's timezone, e.g. "PST", "EDT", etc. This will automatically update based on Daylight Saving Time.</dd>
 </dl>
 
 Dates and times will be formatted [according to the "date format" and "time format" settings for your store](https://wordpress.org/support/article/settings-general-screen/#date-format), respectively.

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -21,8 +21,16 @@ namespace Nexcess\LimitOrders;
  *
  * @param string $class The classname we're attempting to load.
  */
-spl_autoload_register( function ( string $class ) {
-	$filepath = str_replace( __NAMESPACE__ . '\\', '', $class );
+spl_autoload_register( function ( $class ) {
+	$namespace = __NAMESPACE__ . '\\';
+	$class     = (string) $class;
+
+	// Move onto the next registered autoloader if the class is outside of our namespace.
+	if ( 0 !== strncmp( $namespace, $class, strlen( $namespace ) ) ) {
+		return;
+	}
+
+	$filepath = str_replace( $namespace, '', $class );
 	$filepath = __DIR__ . '/src/' . str_replace( '\\', '/', $filepath ) . '.php';
 
 	if ( is_readable( $filepath ) ) {

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -6,7 +6,7 @@
  * Author URI:  https://nexcess.net
  * Text Domain: limit-orders
  * Domain Path: /languages
- * Version:     1.1.2
+ * Version:     1.2.0
  *
  * WC requires at least: 3.9
  * WC tested up to:      4.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Limit Orders for WooCommerce ===
-Contributors: nexcess, liquidweb, stevegrunwell
+Contributors: nexcess, liquidweb, stevegrunwell, bswatson
 Tags: WooCommerce, ordering, limits, throttle
 Requires at least: 5.3
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 1.1.2
+Stable tag: 1.2.0
 License: MIT
 License URI: https://github.com/nexcess/limit-orders/blob/master/LICENSE.txt
 
@@ -45,6 +45,10 @@ Yes, the order creation process through WP Admin is unaffected.
 
 For a complete list of changes, please [see the plugin's changelog on GitHub](https://github.com/nexcess/limit-orders/blob/master/CHANGELOG.md).
 
+= 1.2.0 (2020-04-27) =
+* Add a new "hourly" interval, enabling store owners to limit the number of orders per hour.
+* Added new placeholders for customer-facing messaging.
+
 = 1.1.2 (2020-04-17) =
 * Override WordPress' default "LIMIT" on queries, which was preventing stores with limits > 10 from stopping orders
 
@@ -58,6 +62,9 @@ For a complete list of changes, please [see the plugin's changelog on GitHub](ht
 Initial release of the plugin.
 
 == Upgrade Notice ==
+
+= 1.2.0 =
+Added the ability to limit the number of orders per hour a store can receive.
 
 = 1.1.2 =
 Fixes error that was preventing order limiting from working on stores with limits higher than 10.

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -71,6 +71,19 @@ class Admin {
 			return;
 		}
 
+		// Change what text we show based on how far off it is.
+		$next_interval = $this->limiter->get_next_interval_start();
+		$midnight      = current_datetime()->setTime( 24, 0, 0 );
+
+		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+		if ( $next_interval == $midnight ) {
+			$next = _x( 'midnight', 'beginning of the next day/interval', 'limit-orders' );
+		} elseif ( $next_interval < $midnight ) {
+			$next = $next_interval->format( get_option( 'time_format' ) );
+		} else {
+			$next = $next_interval->format( get_option( 'date_format' ) );
+		}
+
 		echo '<div class="notice notice-warning"><p>';
 
 		if ( current_user_can( 'manage_options' ) ) {
@@ -78,13 +91,13 @@ class Admin {
 				/* Translators: %1$s is the settings page URL, %2$s is the reset date for order limiting. */
 				__( '<a href="%1$s">Based on your store\'s configuration</a>, new orders have been put on hold until %2$s.', 'limit-orders' ),
 				$this->get_settings_url(),
-				$this->limiter->get_next_interval_start()->format( get_option( 'date_format' ) )
+				$next
 			) );
 		} else {
 			echo esc_html( sprintf(
 				/* Translators: %1$s is the reset date for order limiting. */
 				__( 'Based on your store\'s configuration, new orders have been put on hold until %1$s.', 'limit-orders' ),
-				$this->limiter->get_next_interval_start()->format( get_option( 'date_format' ) )
+				$next
 			) );
 		}
 		echo '</p></div>';

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -184,7 +184,7 @@ class OrderLimiter {
 		switch ( $interval ) {
 			case 'hourly':
 				// Start at the top of the current hour.
-				$start = $start->setTime( (int) $start->format( 'h' ), 0, 0 );
+				$start = $start->setTime( (int) $start->format( 'G' ), 0, 0 );
 				break;
 
 			case 'daily':

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -136,6 +136,7 @@ class OrderLimiter {
 			'{next_interval}'         => $next->format( $date_format ),
 			'{next_interval:date}'    => $next->format( $date_format ),
 			'{next_interval:time}'    => $next->format( $time_format ),
+			'{timezone}'              => $next->format( 'T' ),
 		];
 
 		/**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -35,6 +35,16 @@ class Settings extends WC_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings() {
+		$placeholders           = (array) $this->limiter->get_placeholders();
+		$available_placeholders = '';
+
+		// Build a list of available placeholders.
+		if ( ! empty( $placeholders ) ) {
+			$available_placeholders  = __( 'Available placeholders:', 'limit-orders' ) . ' <var>';
+			$available_placeholders .= implode( '</var>, <var>', array_keys( $placeholders ) );
+			$available_placeholders .= '</var>';
+		}
+
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, [
 			[
 				'id'   => 'limit-orders-general',
@@ -75,7 +85,7 @@ class Settings extends WC_Settings_Page {
 				'id'   => 'limit-orders-messaging',
 				'type' => 'title',
 				'name' => _x( 'Customer messaging', 'settings section title', 'limit-orders' ),
-				'desc' => '<p>' . __( 'Customize the messages shown to customers once ordering is disabled.', 'limit-orders' ) . '</p><p>' . __( 'Available placeholders: <var>{limit}</var>, <var>{current_interval}</var>, <var>{next_interval}</var>.', 'limit-orders' ) . '</p>',
+				'desc' => '<p>' . __( 'Customize the messages shown to customers once ordering is disabled.', 'limit-orders' ) . '</p>' . $available_placeholders ? '<p>' . $available_placeholders . '</p>' : '',
 			],
 			[
 				'id'       => OrderLimiter::OPTION_KEY . '[customer_notice]',
@@ -116,6 +126,7 @@ class Settings extends WC_Settings_Page {
 		global $wp_locale;
 
 		$intervals = [
+			'hourly'  => _x( 'Hourly (resets at the top of every hour)', 'order threshold interval', 'limit-orders' ),
 			'daily'   => _x( 'Daily (resets every day)', 'order threshold interval', 'limit-orders' ),
 			'weekly'  => sprintf(
 				/* Translators: %1$s is the first day of the week, based on site configuration. */

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -345,6 +345,26 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @depends get_interval_start_for_hourly
+	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/24
+	 */
+	public function get_interval_start_should_use_24hr_time() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now   = new \DateTimeImmutable( '2020-04-27 18:05:00', wp_timezone() );
+		$start = new \DateTimeImmutable( '2020-04-27 18:00:00', wp_timezone() );
+
+		$this->assertSame(
+			$start->format( 'r' ),
+			( new OrderLimiter( $now ) )->get_interval_start()->format( 'r' )
+		);
+	}
+
+	/**
+	 * @test
 	 * @group Intervals
 	 */
 	public function get_interval_start_for_daily() {

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -224,6 +224,8 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 * @group Placeholders
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 * @ticket https://github.com/nexcess/limit-orders/issues/22
 	 */
 	public function get_placeholders_should_return_an_array_of_default_placeholders() {
 		update_option( 'date_format', 'F j, Y' );
@@ -243,6 +245,7 @@ class OrderLimiterTest extends TestCase {
 		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval}'] );
 		$this->assertSame( $next->format( 'F j, Y' ), $placeholders['{next_interval:date}'] );
 		$this->assertSame( $next->format( 'g:ia' ), $placeholders['{next_interval:time}'] );
+		$this->assertSame( $next->format( 'T' ), $placeholders['{timezone}'] );
 	}
 
 	/**

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -30,6 +30,24 @@ class SettingsTest extends TestCase {
 
 	/**
 	 * @test
+	 * @group Intervals
+	 * @ticket https://github.com/nexcess/limit-orders/issues/18
+	 */
+	public function it_should_include_default_intervals() {
+		$method = new \ReflectionMethod( Settings::class, 'get_intervals' );
+		$method->setAccessible( true );
+
+		$intervals = $method->invoke( new Settings( new OrderLimiter() ) );
+
+		$this->assertArrayHasKey( 'daily', $intervals );
+		$this->assertArrayHasKey( 'weekly', $intervals );
+		$this->assertArrayHasKey( 'monthly', $intervals );
+		$this->assertArrayHasKey( 'hourly', $intervals, 'Hourly was added in https://github.com/nexcess/limit-orders/issues/18' );
+	}
+
+	/**
+	 * @test
+	 * @group Intervals
 	 */
 	public function available_intervals_should_be_filterable() {
 		$intervals = [
@@ -51,5 +69,24 @@ class SettingsTest extends TestCase {
 		}
 
 		$this->fail( 'Did not find setting with ID "'. OrderLimiter::OPTION_KEY . '[interval]".' );
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 */
+	public function available_placeholders_should_be_shown_in_the_messages_section() {
+		$limiter  = new OrderLimiter();
+		$sections = array_filter( ( new Settings( new OrderLimiter() ) )->get_settings(), function ( $section ) {
+			return 'limit-orders-messaging' === $section['id'] && 'title' === $section['type'];
+		} );
+
+		$this->assertCount( 1, $sections, 'Expected to see only one instance of "limit-orders-messaging".' );
+
+		$description = current( $sections )['desc'];
+
+		foreach ( $limiter->get_placeholders() as $placeholder => $value ) {
+			$this->assertContains( '<var>' . $placeholder . '</var>', $description );
+		}
 	}
 }


### PR DESCRIPTION
## Added

* Added "hourly" as a default interval for stores (#20).
* Added new placeholders to user-facing messaging (#20, #26):
	- `{current_interval:date}` (alias of `{current_interval}`)
	- `{current_interval:time}`
	- `{next_interval:date}` (alias of `{next_interval}`)
	- `{next_interval:time}`
	- `{timezone}`
* Added documentation for adding custom intervals, placeholders (#23).

## Updated

* The settings screen will now show custom placeholders that have been registered via the "limit_orders_message_placeholders" filter (#20).
* Improve autoloader performance and remove type-hint from PSR-4 autoloader (#17).