### PR TITLE
Fix example code for defining custom intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You may accomplish this by adding the following code into your theme's `function
  */
 
 /**
- * Add "fortnightly" to the list of intervals.
+ * Add "Annually" to the list of intervals.
  *
  * @param array $intervals Available time intervals.
  *
@@ -160,7 +160,7 @@ add_filter( 'limit_orders_interval_start', function ( $start, $interval ) {
  *                   current $interval is not "annually".
  */
 add_filter( 'limit_orders_next_interval', function ( $start, $current, $interval ) {
-	if ( 'annually' !== 'interval' ) {
+	if ( 'annually' !== $interval ) {
 		return $start;
 	}
 


### PR DESCRIPTION
I used our example code as a basis when responding to https://wordpress.org/support/topic/limit-per-minute/, and noticed two issues in our example code:

1. A leftover reference to "fortnightly" (from an earlier version of that sample code)
2. Comparing the custom interval against the string "interval", not the variable `$interval`, when calculating the start of the next interval. This was resulting in the next interval being the same as the current.