### PR TITLE
Push readme and/or asset changes to WordPress.org automatically

### DIFF
--- a/.github/workflows/update-wordpress-org-assets.yml
+++ b/.github/workflows/update-wordpress-org-assets.yml
@@ -1,0 +1,18 @@
+name: Update assets on WordPress.org
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  master:
+    name: Send to WordPress.org
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Push readme.txt and/or asset changes
+      uses: 10up/action-wordpress-plugin-asset-update@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
This PR introduces a new workflow, using [10up's WordPress.org Plugin Readme/Assets Update GitHub action](https://github.com/10up/action-wordpress-plugin-asset-update).

When changes to the readme.txt file and/or anything in `.wordpress-org/` gets pushed on the `master` branch, these assets will automatically be sent to WordPress.org. This makes it easier to, for example, bump the "Tested up to" values without requiring a whole new release