### PR TITLE
Use WordPress 5.3 in the "Minimum Requirements" CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: WP_TRAVISCI=phpstan
     - name: Minimum requirements
       php: 7.0
-      env: WP_VERSION=5.2 WC_VERSION=3.9.3
+      env: WP_VERSION=5.3 WC_VERSION=3.9.3
     - name: Bleeding Edge
       php: 7.4
       env: WP_VERSION=trunk WC_VERSION=latest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Limit Orders for WooCommerce lets you limit the number of orders your store will
 
 ## Requirements
 
-* WordPress 5.2 or newer
+* WordPress 5.3 or newer
 * WooCommerce 3.9 or newer
 * PHP 7.0 or newer
 


### PR DESCRIPTION
The plugin headers declare WordPress 5.3 as the minimum supported version, yet the "Minimum requirements" Travis CI job was using WordPress 5.2.

The reason we use 5.3 is for [the date/time improvements](https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/), as well as the fact that 5.2 is old (current WP release branch is 5.4.x); there's no sense in polyfilling this functionality as store owners *should* be running the latest version of WordPress.

However, running the test suite against WordPress 5.2 produces a bunch of noise, as pretty much every test has some reliance on WP 5.3's date/time handling ([example](https://travis-ci.org/github/nexcess/limit-orders/jobs/699743757)).