### PR TITLE
Register a "Reset Order Limiting" WooCommerce tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Configuration for Limit Orders for WooCommerce is available through WooCommerce 
 
 For example, if you're using an hourly interval and switch it to daily, the plugin will re-calculate whether or not to disable ordering based on the number of orders received since the start of the current day (midnight, by default).
 
+If you need to clear the cached order count, you may do so via WooCommerce &rsaquo; Status &rsaquo; Tools &rsaquo; Reset Order Limiting within WP Admin.
+
 ### General settings
 
 These settings determine how and when order limiting should take effect.

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -136,7 +136,7 @@ class Admin {
 	 * Delete the order limiter transient.
 	 */
 	public function reset_limiter() {
-		$this->limiter->reset_limiter( 1, 2 );
+		$this->limiter->reset();
 	}
 
 	/**

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -32,6 +32,8 @@ class Admin {
 		add_filter( 'woocommerce_get_settings_pages', [ $this, 'register_settings_page' ] );
 		add_filter( 'admin_notices', [ $this, 'admin_notice' ] );
 		add_filter( 'plugin_action_links_' . $basename, [ $this, 'action_links' ] );
+		add_filter( 'woocommerce_debug_tools', [ $this, 'debug_tools' ] );
+		add_action( 'woocommerce_delete_shop_order_transients', [ $this, 'reset_limiter' ] );
 		add_action( 'woocommerce_system_status_report', [ $this, 'system_status_report' ] );
 	}
 
@@ -110,6 +112,31 @@ class Admin {
 		$this->render_view( 'SystemStatusReport', [
 			'limiter' => $this->limiter,
 		] );
+	}
+
+	/**
+	 * Add additional debugging tools.
+	 *
+	 * @param array $tools Currently-registered tools.
+	 *
+	 * @return array The $tools array with our button included.
+	 */
+	public function debug_tools( $tools ) {
+		$tools['limit_orders'] = [
+			'name'     => __( 'Reset order limiting', 'limit-orders' ),
+			'button'   => __( 'Reset limiter', 'limit-orders' ),
+			'desc'     => __( 'Clear the cached order count. This may be needed if you\'ve changed your order limiting settings.', 'limit-orders' ),
+			'callback' => [ $this, 'reset_limiter' ],
+		];
+
+		return $tools;
+	}
+
+	/**
+	 * Delete the order limiter transient.
+	 */
+	public function reset_limiter() {
+		$this->limiter->reset_limiter( 1, 2 );
 	}
 
 	/**

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -50,7 +50,7 @@ class OrderLimiter {
 	 */
 	public function init() {
 		add_action( 'woocommerce_new_order', [ $this, 'regenerate_transient' ] );
-		add_action( 'update_option_' . self::OPTION_KEY, [ $this, 'reset_limiter' ], 10, 2 );
+		add_action( 'update_option_' . self::OPTION_KEY, [ $this, 'reset_limiter_on_update' ], 10, 2 );
 	}
 
 	/**
@@ -360,14 +360,21 @@ class OrderLimiter {
 	}
 
 	/**
+	 * Reset the order limiter.
+	 */
+	public function reset() {
+		delete_transient( self::TRANSIENT_NAME );
+	}
+
+	/**
 	 * Reset the limiter when its configuration changes.
 	 *
 	 * @param mixed $previous The previous value of the option.
 	 * @param mixed $new      The new option value.
 	 */
-	public function reset_limiter( $previous, $new ) {
+	public function reset_limiter_on_update( $previous, $new ) {
 		if ( $previous !== $new ) {
-			delete_transient( self::TRANSIENT_NAME );
+			$this->reset();
 		}
 	}
 

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -9,6 +9,8 @@ namespace Tests;
 
 use Nexcess\LimitOrders\Admin;
 use Nexcess\LimitOrders\OrderLimiter;
+use WC_Admin_Status;
+use WC_REST_System_Status_Tools_V2_Controller;
 
 /**
  * @covers Nexcess\LimitOrders\Admin
@@ -125,5 +127,41 @@ class AdminTest extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertContains( __( 'midnight' ), $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function the_plugin_should_register_a_debug_tool() {
+		( new Admin( new OrderLimiter() ) )->init();
+
+		$this->assertArrayHasKey( 'limit_orders', WC_Admin_Status::get_tools() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function the_debug_tool_should_clear_the_order_count_transient() {
+		set_transient( OrderLimiter::TRANSIENT_NAME, 5 );
+
+		( new Admin( new OrderLimiter() ) )->init();
+
+		$controller = new WC_REST_System_Status_Tools_V2_Controller();
+		$controller->execute_tool( 'limit_orders' );
+
+		$this->assertFalse( get_transient( OrderLimiter::TRANSIENT_NAME ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function clearing_order_transients_should_remove_the_order_count() {
+		set_transient( OrderLimiter::TRANSIENT_NAME, 5 );
+
+		( new Admin( new OrderLimiter() ) )->init();
+
+		wc_delete_shop_order_transients();
+
+		$this->assertFalse( get_transient( OrderLimiter::TRANSIENT_NAME ) );
 	}
 }

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -851,6 +851,17 @@ class OrderLimiterTest extends TestCase {
 	/**
 	 * @test
 	 */
+	public function reset_should_delete_the_transient_cache() {
+		set_transient( OrderLimiter::TRANSIENT_NAME, 5 );
+
+		( new OrderLimiter() )->reset();
+
+		$this->assertFalse( get_transient( OrderLimiter::TRANSIENT_NAME ) );
+	}
+
+	/**
+	 * @test
+	 */
 	public function the_transient_should_be_updated_each_time_an_order_is_placed() {
 		update_option( OrderLimiter::OPTION_KEY, [
 			'enabled'  => true,


### PR DESCRIPTION
This PR registers a new tool within the WooCommerce > Status > Tools page that lets store administrators clear the order limiter transient.

Additionally, clearing all WooCommerce order transients (via `wc_delete_shop_order_transients()`, which is called as part of the "WooCommerce transients" tool), will clear our limiter transient as well.

Fixes #35.