### PR TITLE
Bump the "WC tested up to" to version 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ php:
 # To keep the test matrix from exploding over time, we'll actively test against the latest three
 # releases, then cherry-pick what to test across older ones.
 env:
+  - WP_VERSION=latest WC_VERSION=4.3
   - WP_VERSION=latest WC_VERSION=4.2
   - WP_VERSION=latest WC_VERSION=4.1
-  - WP_VERSION=latest WC_VERSION=4.0
   - WP_VERSION=latest WC_VERSION=3.9.3
 
 matrix:

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -14,7 +14,7 @@
  * Domain Path:       /languages
  *
  * WC requires at least: 3.9
- * WC tested up to:      4.2
+ * WC tested up to:      4.3
  *
  * @package Nexcess\LimitOrders
  */


### PR DESCRIPTION
WooCommerce 4.3 was released last week, so this PR bumps the "WC tested up to" value in the plugin header to match.

Naturally, this also puts 4.3 into the (explicit) Travis testing matrix.