### PR TITLE
Use assertContains() instead of assertStringContainsString()

### DIFF
--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -91,7 +91,7 @@ class SettingsTest extends TestCase {
 		$limiter = new OrderLimiter();
 		$limiter->init();
 
-		$this->assertStringContainsString(
+		$this->assertContains(
 			'<div class="notice notice-info">',
 			$this->get_setting_by_id( 'limit-orders-general', new Settings( $limiter ) )['desc'],
 			'Expected to see a notice about limits being recalculated.'
@@ -111,7 +111,7 @@ class SettingsTest extends TestCase {
 		$limiter = new OrderLimiter();
 		$limiter->init();
 
-		$this->assertStringNotContainsString(
+		$this->assertNotContains(
 			'<div class="notice notice-info">',
 			$this->get_setting_by_id( 'limit-orders-general', new Settings( $limiter ) )['desc'],
 			'Did not expect to see a notice about limits being recalculated.'


### PR DESCRIPTION
The latter method wasn't introduced until PHPUnit 7.5, which means we'd either need to polyfill the method for PHPUnit 6.x (required for PHP 7.0) *or* just use `assertContains()` until we're able to drop PHP 7.0.