### PR TITLE
Bump the "Tested Up To" value to WordPress 5.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nexcess, liquidweb, stevegrunwell, bswatson
 Tags: WooCommerce, ordering, limits, throttle
 Requires at least: 5.3
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 7.0
 Stable tag: 1.3.0
 License: MIT


### PR DESCRIPTION
This should also be the first real test of [10up's WordPress.org Plugin Readme/Assets GitHub action](https://github.com/10up/action-wordpress-plugin-asset-update) we installed back in #34.

Fixes #46.