### PR TITLE
Prevent the order count transient from being set before $wc_order_types is populated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "@test:standards",
             "@test:analysis"
         ],
-        "test:analysis": "vendor/bin/phpstan analyze",
+        "test:analysis": "vendor/bin/phpstan analyze -c phpstan.neon.dist",
         "test:standards": "vendor/bin/phpcs",
         "test:unit": "vendor/bin/phpunit --testdox --color=always"
     },

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -44,7 +44,13 @@ spl_autoload_register( function ( $class ) {
 } );
 
 // Initialize the plugin.
-add_action( 'woocommerce_loaded', function () {
+add_action( 'init', function () {
+
+	// Abort if WooCommerce hasn't loaded.
+	if ( ! did_action( 'woocommerce_loaded' ) ) {
+		return;
+	}
+
 	$limiter = new OrderLimiter();
 	$admin   = new Admin( $limiter );
 

--- a/src/Exceptions/EmptyOrderTypesException.php
+++ b/src/Exceptions/EmptyOrderTypesException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Thrown when wc_get_order_types() returns empty.
+ *
+ * @package Nexcess\LimitOrders
+ */
+
+namespace Nexcess\LimitOrders\Exceptions;
+
+class EmptyOrderTypesException extends \Exception {
+
+}

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -7,6 +7,7 @@
 
 namespace Nexcess\LimitOrders;
 
+use Nexcess\LimitOrders\Exceptions\EmptyOrderTypesException;
 use Nexcess\LimitOrders\Exceptions\OrdersNotAcceptedException;
 
 class OrderLimiter {
@@ -367,7 +368,13 @@ class OrderLimiter {
 	 * @return int The number of qualifying orders.
 	 */
 	public function regenerate_transient() {
-		$count = $this->count_qualifying_orders();
+		try {
+			$count = $this->count_qualifying_orders();
+		} catch ( EmptyOrderTypesException $e ) {
+			// Return 0 for now but try to populate this transient later, after $wc_order_types has been populated.
+			add_action( 'init', [ $this, 'regenerate_transient' ] );
+			return 0;
+		}
 
 		set_transient( self::TRANSIENT_NAME, $count, $this->get_seconds_until_next_interval() );
 
@@ -402,7 +409,7 @@ class OrderLimiter {
 		/**
 		 * Replace the logic used to count qualified orders.
 		 *
-		 * @param bool $preempt         Whether the counting logic should be preempted. Returning
+		 * @param bool         $preempt Whether the counting logic should be preempted. Returning
 		 *                              anything but FALSE will bypass the default logic.
 		 * @param OrderLimiter $limiter The current OrderLimiter instance.
 		 */
@@ -412,8 +419,14 @@ class OrderLimiter {
 			return (int) $count;
 		}
 
+		$order_types = wc_get_order_types( 'order-count' );
+
+		if ( empty( $order_types ) ) {
+			throw new EmptyOrderTypesException( 'No order types were found.' );
+		}
+
 		$orders = wc_get_orders( [
-			'type'         => wc_get_order_types( 'order-count' ),
+			'type'         => $order_types,
 			'date_created' => '>=' . $this->get_interval_start()->getTimestamp(),
 			'return'       => 'ids',
 			'limit'        => max( $this->get_limit(), 1000 ),

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -699,9 +699,7 @@ class OrderLimiterTest extends TestCase {
 		$limiter->init();
 
 		$this->assertFalse( $limiter->has_orders_in_current_interval() );
-
-		$this->generate_order();
-
+		$this->set_current_order_count( 1 );
 		$this->assertTrue( $limiter->has_orders_in_current_interval() );
 	}
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -88,8 +88,7 @@ class SettingsTest extends TestCase {
 
 		$limiter = new OrderLimiter();
 		$limiter->init();
-
-		$this->generate_order();
+		$this->set_current_order_count( 1 );
 
 		$this->assertContains(
 			'<div class="notice notice-info">',
@@ -110,6 +109,7 @@ class SettingsTest extends TestCase {
 
 		$limiter = new OrderLimiter();
 		$limiter->init();
+		$this->set_current_order_count( 0 );
 
 		$this->assertNotContains(
 			'<div class="notice notice-info">',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@
 
 namespace Tests;
 
+use Nexcess\LimitOrders\OrderLimiter;
 use WC_Checkout;
 use WC_Helper_Product;
 use WP_UnitTestCase;
@@ -30,5 +31,14 @@ abstract class TestCase extends WP_UnitTestCase {
 			'billing_email'  => 'test_customer@example.com',
 			'payment_method' => 'dummy_payment_gateway',
 		] );
+	}
+
+	/**
+	 * Explicitly set the current interval's order count.
+	 *
+	 * @param int $orders The current number of orders.
+	 */
+	protected function set_current_order_count( $orders ) {
+		set_transient( OrderLimiter::TRANSIENT_NAME, (int) $orders );
 	}
 }


### PR DESCRIPTION
This PR defers the generation of the `OrderLimiter::TRANSIENT_NAME` transient until after WooCommerce populates its `$wc_order_types` variable (by default, this occurs at init:5).

Additionally, if the plugin is attempting to generate the transient while `$wc_order_types` is empty, the plugin will automatically re-queue the operation until init:10, ensuring it still happens on the given request (just later than intended).

Fixes #48.