### PR TITLE
Change the format of the {current_interval} and {next_interval} placeholders if the interval is less than 24 hours

### DIFF
--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -129,12 +129,13 @@ class OrderLimiter {
 		$time_format  = get_option( 'time_format' );
 		$current      = $this->get_interval_start();
 		$next         = $this->get_next_interval_start();
+		$within24hr   = $next->getTimestamp() - $current->getTimestamp() < DAY_IN_SECONDS;
 		$placeholders = [
-			'{current_interval}'      => $current->format( $date_format ),
+			'{current_interval}'      => $current->format( $within24hr ? $time_format : $date_format ),
 			'{current_interval:date}' => $current->format( $date_format ),
 			'{current_interval:time}' => $current->format( $time_format ),
 			'{limit}'                 => $this->get_limit(),
-			'{next_interval}'         => $next->format( $date_format ),
+			'{next_interval}'         => $next->format( $within24hr ? $time_format : $date_format ),
 			'{next_interval:date}'    => $next->format( $date_format ),
 			'{next_interval:time}'    => $next->format( $time_format ),
 			'{timezone}'              => $next->format( 'T' ),

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -228,12 +228,12 @@ class OrderLimiterTest extends TestCase {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval' => 'hourly',
+			'interval' => 'daily',
 		] );
 
-		$now          = new \DateTimeImmutable( '2020-04-27 12:15:00', wp_timezone() );
-		$current      = new \DateTimeImmutable( '2020-04-27 12:00:00', wp_timezone() );
-		$next         = new \DateTimeImmutable( '2020-04-27 13:00:00', wp_timezone() );
+		$now          = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
 
 		$this->assertSame( $current->format( 'F j, Y' ), $placeholders['{current_interval}'] );
@@ -263,6 +263,26 @@ class OrderLimiterTest extends TestCase {
 
 		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{current_interval:time}'] );
 		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{next_interval:time}'] );
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 * @ticket https://github.com/nexcess/limit-orders/issues/51
+	 */
+	public function placeholders_should_switch_between_date_and_time_based_on_interval_length() {
+		update_option( 'time_format', 'g:ia' );
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now          = new \DateTimeImmutable( '2020-09-17 12:15:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-09-17 12:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-09-17 13:00:00', wp_timezone() );
+		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
+
+		$this->assertSame( $current->format( 'g:ia' ), $placeholders['{current_interval}'] );
+		$this->assertSame( $next->format( 'g:ia' ), $placeholders['{next_interval}'] );
 	}
 
 	/**

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -122,11 +122,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_current_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'weekly',
+			'interval'        => 'monthly',
 			'customer_notice' => "This started on {$placeholder}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -143,11 +143,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_current_interval_time_placeholder() {
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'hourly',
+			'interval'        => 'monthly',
 			'customer_notice' => "This started at {current_interval:time}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -184,11 +184,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_next_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'weekly',
+			'interval'        => 'monthly',
 			'customer_notice' => "Check back on {$placeholder}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -205,11 +205,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_next_interval_time_placeholder() {
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'hourly',
+			'interval'        => 'monthly',
 			'customer_notice' => "Check back at {next_interval:time}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(


### PR DESCRIPTION
If the interval is less than 24 hours, the `{current_interval}` and `{next_interval}` placeholders should use the **time**, not the **date**.

Fixes #51.