### PR TITLE
Version 1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ php:
 # To keep the test matrix from exploding over time, we'll actively test against the latest three
 # releases, then cherry-pick what to test across older ones.
 env:
+  - WP_VERSION=latest WC_VERSION=4.5
+  - WP_VERSION=latest WC_VERSION=4.4
   - WP_VERSION=latest WC_VERSION=4.3
-  - WP_VERSION=latest WC_VERSION=4.2
-  - WP_VERSION=latest WC_VERSION=4.1
   - WP_VERSION=latest WC_VERSION=3.9.3
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Version 1.3.1] — 2020-09-17
+
+### Fixed
+
+* Prevent the order count transient from being set before $wc_order_types is populated ([#52])
+
+### Changed
+
+* Move the limiter initialization from "woocommerce_loaded" to "init" ([#52])
+* Change the format of the `{current_interval}` and `{next_interval}` placeholders if the interval is less than 24 hours ([#53])
+
 
 ## [Version 1.3.0] — 2020-07-16
 
@@ -85,6 +98,7 @@ Initial plugin release.
 [Version 1.2.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.2.0
 [Version 1.2.1]: https://github.com/nexcess/limit-orders/releases/tag/v1.2.1
 [Version 1.3.0]: https://github.com/nexcess/limit-orders/releases/tag/v1.3.0
+[Version 1.3.1]: https://github.com/nexcess/limit-orders/releases/tag/v1.3.1
 [#5]: https://github.com/nexcess/limit-orders/pull/5
 [#6]: https://github.com/nexcess/limit-orders/pull/6
 [#8]: https://github.com/nexcess/limit-orders/pull/8
@@ -100,3 +114,5 @@ Initial plugin release.
 [#41]: https://github.com/nexcess/limit-orders/pull/41
 [#42]: https://github.com/nexcess/limit-orders/pull/42
 [#43]: https://github.com/nexcess/limit-orders/pull/43
+[#52]: https://github.com/nexcess/limit-orders/pull/52
+[#53]: https://github.com/nexcess/limit-orders/pull/53

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "@test:standards",
             "@test:analysis"
         ],
-        "test:analysis": "vendor/bin/phpstan analyze",
+        "test:analysis": "vendor/bin/phpstan analyze -c phpstan.neon.dist",
         "test:standards": "vendor/bin/phpcs",
         "test:unit": "vendor/bin/phpunit --testdox --color=always"
     },

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -44,7 +44,13 @@ spl_autoload_register( function ( $class ) {
 } );
 
 // Initialize the plugin.
-add_action( 'woocommerce_loaded', function () {
+add_action( 'init', function () {
+
+	// Abort if WooCommerce hasn't loaded.
+	if ( ! did_action( 'woocommerce_loaded' ) ) {
+		return;
+	}
+
 	$limiter = new OrderLimiter();
 	$admin   = new Admin( $limiter );
 

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Limit Orders for WooCommerce
  * Plugin URI:        https://wordpress.org/plugins/limit-orders/
  * Description:       Automatically disable WooCommerce's checkout process after reaching a maximum number of orders.
- * Version:           1.3.0
+ * Version:           1.3.1
  * Requires at least: 5.3
  * Requires PHP:      7.0
  * License:           MIT

--- a/limit-orders.php
+++ b/limit-orders.php
@@ -14,7 +14,7 @@
  * Domain Path:       /languages
  *
  * WC requires at least: 3.9
- * WC tested up to:      4.3
+ * WC tested up to:      4.5
  *
  * @package Nexcess\LimitOrders
  */

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,10 @@ The plugin is designed to work based on the total number of orders, but as of ve
 
 For a complete list of changes, please [see the plugin's changelog on GitHub](https://github.com/nexcess/limit-orders/blob/master/CHANGELOG.md).
 
+= 1.3.1 (2020-09-17) =
+* Fixed issue where clearing transients would prevent the order limiting from working.
+* Clarify the behavior of the {current_interval} and {next_interval} placeholders.
+
 = 1.3.0 (2020-07-16) =
 * Added new "Reset order limiting" WooCommerce tool.
 * Introduce new filters for customizing order counting logic.
@@ -83,6 +87,9 @@ For a complete list of changes, please [see the plugin's changelog on GitHub](ht
 Initial release of the plugin.
 
 == Upgrade Notice ==
+
+= 1.3.1 =
+Fixes issue where limiting would periodically stop working
 
 = 1.2.0 =
 Added the ability to limit the number of orders per hour a store can receive.

--- a/src/Exceptions/EmptyOrderTypesException.php
+++ b/src/Exceptions/EmptyOrderTypesException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Thrown when wc_get_order_types() returns empty.
+ *
+ * @package Nexcess\LimitOrders
+ */
+
+namespace Nexcess\LimitOrders\Exceptions;
+
+class EmptyOrderTypesException extends \Exception {
+
+}

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -7,6 +7,7 @@
 
 namespace Nexcess\LimitOrders;
 
+use Nexcess\LimitOrders\Exceptions\EmptyOrderTypesException;
 use Nexcess\LimitOrders\Exceptions\OrdersNotAcceptedException;
 
 class OrderLimiter {
@@ -367,7 +368,13 @@ class OrderLimiter {
 	 * @return int The number of qualifying orders.
 	 */
 	public function regenerate_transient() {
-		$count = $this->count_qualifying_orders();
+		try {
+			$count = $this->count_qualifying_orders();
+		} catch ( EmptyOrderTypesException $e ) {
+			// Return 0 for now but try to populate this transient later, after $wc_order_types has been populated.
+			add_action( 'init', [ $this, 'regenerate_transient' ] );
+			return 0;
+		}
 
 		set_transient( self::TRANSIENT_NAME, $count, $this->get_seconds_until_next_interval() );
 
@@ -402,7 +409,7 @@ class OrderLimiter {
 		/**
 		 * Replace the logic used to count qualified orders.
 		 *
-		 * @param bool $preempt         Whether the counting logic should be preempted. Returning
+		 * @param bool         $preempt Whether the counting logic should be preempted. Returning
 		 *                              anything but FALSE will bypass the default logic.
 		 * @param OrderLimiter $limiter The current OrderLimiter instance.
 		 */
@@ -412,8 +419,14 @@ class OrderLimiter {
 			return (int) $count;
 		}
 
+		$order_types = wc_get_order_types( 'order-count' );
+
+		if ( empty( $order_types ) ) {
+			throw new EmptyOrderTypesException( 'No order types were found.' );
+		}
+
 		$orders = wc_get_orders( [
-			'type'         => wc_get_order_types( 'order-count' ),
+			'type'         => $order_types,
 			'date_created' => '>=' . $this->get_interval_start()->getTimestamp(),
 			'return'       => 'ids',
 			'limit'        => max( $this->get_limit(), 1000 ),

--- a/src/OrderLimiter.php
+++ b/src/OrderLimiter.php
@@ -130,12 +130,13 @@ class OrderLimiter {
 		$time_format  = get_option( 'time_format' );
 		$current      = $this->get_interval_start();
 		$next         = $this->get_next_interval_start();
+		$within24hr   = $next->getTimestamp() - $current->getTimestamp() < DAY_IN_SECONDS;
 		$placeholders = [
-			'{current_interval}'      => $current->format( $date_format ),
+			'{current_interval}'      => $current->format( $within24hr ? $time_format : $date_format ),
 			'{current_interval:date}' => $current->format( $date_format ),
 			'{current_interval:time}' => $current->format( $time_format ),
 			'{limit}'                 => $this->get_limit(),
-			'{next_interval}'         => $next->format( $date_format ),
+			'{next_interval}'         => $next->format( $within24hr ? $time_format : $date_format ),
 			'{next_interval:date}'    => $next->format( $date_format ),
 			'{next_interval:time}'    => $next->format( $time_format ),
 			'{timezone}'              => $next->format( 'T' ),

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -9,6 +9,7 @@ namespace Tests;
 
 use Nexcess\LimitOrders\OrderLimiter;
 use WC_Helper_Product;
+use WC_Order;
 
 /**
  * @covers Nexcess\LimitOrders\OrderLimiter
@@ -962,6 +963,51 @@ class OrderLimiterTest extends TestCase {
 		update_option( OrderLimiter::OPTION_KEY, get_option( OrderLimiter::OPTION_KEY ) );
 
 		$this->assertSame( $transient, get_transient( OrderLimiter::TRANSIENT_NAME ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function count_qualifying_orders_should_focus_only_on_orders() {
+		$this->factory()->post->create();
+		$this->factory()->post->create( [
+			'post_type' => 'page',
+		] );
+		$this->generate_order();
+
+		// To avoid race conditions, start the current interval 30s ago.
+		$instance = new OrderLimiter( new \DateTimeImmutable( '30 seconds ago' ) );
+		$method   = new \ReflectionMethod( $instance, 'count_qualifying_orders' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 1, $method->invoke( $instance ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function count_qualifying_orders_should_limit_based_on_interval() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'enabled'  => true,
+			'interval' => 'hourly',
+		] );
+
+		$instance = new OrderLimiter();
+		$this->generate_order();
+		$this->generate_order();
+
+		$previous = new WC_Order( $this->generate_order() );
+		$previous->set_date_created(
+			$instance->get_interval_start()
+				->sub( new \DateInterval( 'PT1M' ) ) // 1min before the current interval began.
+				->format( 'u' )
+		);
+		$previous->save();
+
+		$method = new \ReflectionMethod( $instance, 'count_qualifying_orders' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 2, $method->invoke( $instance ) );
 	}
 
 	/**

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -7,6 +7,7 @@
 
 namespace Tests;
 
+use Nexcess\LimitOrders\Exceptions\EmptyOrderTypesException;
 use Nexcess\LimitOrders\OrderLimiter;
 use WC_Helper_Product;
 use WC_Order;
@@ -699,9 +700,7 @@ class OrderLimiterTest extends TestCase {
 		$limiter->init();
 
 		$this->assertFalse( $limiter->has_orders_in_current_interval() );
-
-		$this->generate_order();
-
+		$this->set_current_order_count( 1 );
 		$this->assertTrue( $limiter->has_orders_in_current_interval() );
 	}
 
@@ -891,6 +890,35 @@ class OrderLimiterTest extends TestCase {
 
 	/**
 	 * @test
+	 * @ticket https://github.com/nexcess/limit-orders/issues/48
+	 */
+	public function regenerate_transient_should_return_zero_if_no_count_is_available() {
+		update_option( OrderLimiter::OPTION_KEY, [
+			'enabled'  => true,
+			'interval' => 'daily',
+			'limit'    => 5,
+		] );
+
+		$this->assertFalse( get_transient( OrderLimiter::TRANSIENT_NAME ) );
+
+		$limiter = $this->getMockBuilder( OrderLimiter::class )
+			->setMethods( [ 'count_qualifying_orders' ] )
+			->getMock();
+		$limiter->expects( $this->once() )
+			->method( 'count_qualifying_orders' )
+			->will( $this->throwException( new EmptyOrderTypesException( 'No order types were found.' ) ) );
+
+		$this->assertSame( 0, $limiter->regenerate_transient() );
+		$this->assertFalse( get_transient( OrderLimiter::TRANSIENT_NAME ) );
+		$this->assertGreaterThan(
+			5,
+			has_action( 'init', [ $limiter, 'regenerate_transient' ] ),
+			'The function should attempt to save itself by hooking in after $wc_order_types is populated (init:5).'
+		);
+	}
+
+	/**
+	 * @test
 	 */
 	public function reset_should_delete_the_transient_cache() {
 		set_transient( OrderLimiter::TRANSIENT_NAME, 5 );
@@ -1058,6 +1086,27 @@ class OrderLimiterTest extends TestCase {
 
 		$this->assertSame( 5, $method->invoke( $instance ) );
 		$this->assertTrue( $called );
+	}
+
+	/**
+	 * @test
+	 * @ticket https://github.com/nexcess/limit-orders/issues/48
+	 */
+	public function count_qualifying_orders_should_throw_an_EmptyOrderTypesException_if_order_types_are_empty() {
+		global $wc_order_types;
+
+		$wc_order_types = [];
+		$instance       = new OrderLimiter();
+		$method         = new \ReflectionMethod( $instance, 'count_qualifying_orders' );
+		$method->setAccessible( true );
+
+		update_option( OrderLimiter::OPTION_KEY, [
+			'enabled' => true,
+			'limit'   => 1,
+		] );
+
+		$this->expectException( EmptyOrderTypesException::class );
+		$method->invoke( $instance );
 	}
 
 	/**

--- a/tests/OrderLimiterTest.php
+++ b/tests/OrderLimiterTest.php
@@ -124,11 +124,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_current_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'weekly',
+			'interval'        => 'monthly',
 			'customer_notice' => "This started on {$placeholder}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -145,11 +145,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_current_interval_time_placeholder() {
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'hourly',
+			'interval'        => 'monthly',
 			'customer_notice' => "This started at {current_interval:time}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -186,11 +186,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_next_interval_placeholder( $placeholder ) {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'weekly',
+			'interval'        => 'monthly',
 			'customer_notice' => "Check back on {$placeholder}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -207,11 +207,11 @@ class OrderLimiterTest extends TestCase {
 	public function get_message_should_replace_next_interval_time_placeholder() {
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval'        => 'hourly',
+			'interval'        => 'monthly',
 			'customer_notice' => "Check back at {next_interval:time}",
 		] );
 
-		$now     = new \DateTimeImmutable( 'now', wp_timezone() );
+		$now     = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
 		$limiter = new OrderLimiter( $now );
 
 		$this->assertSame(
@@ -230,12 +230,12 @@ class OrderLimiterTest extends TestCase {
 		update_option( 'date_format', 'F j, Y' );
 		update_option( 'time_format', 'g:ia' );
 		update_option( OrderLimiter::OPTION_KEY, [
-			'interval' => 'hourly',
+			'interval' => 'daily',
 		] );
 
-		$now          = new \DateTimeImmutable( '2020-04-27 12:15:00', wp_timezone() );
-		$current      = new \DateTimeImmutable( '2020-04-27 12:00:00', wp_timezone() );
-		$next         = new \DateTimeImmutable( '2020-04-27 13:00:00', wp_timezone() );
+		$now          = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-04-27 00:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-04-28 00:00:00', wp_timezone() );
 		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
 
 		$this->assertSame( $current->format( 'F j, Y' ), $placeholders['{current_interval}'] );
@@ -265,6 +265,26 @@ class OrderLimiterTest extends TestCase {
 
 		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{current_interval:time}'] );
 		$this->assertSame( __( 'midnight', 'limit-orders' ), $placeholders['{next_interval:time}'] );
+	}
+
+	/**
+	 * @test
+	 * @group Placeholders
+	 * @ticket https://github.com/nexcess/limit-orders/issues/51
+	 */
+	public function placeholders_should_switch_between_date_and_time_based_on_interval_length() {
+		update_option( 'time_format', 'g:ia' );
+		update_option( OrderLimiter::OPTION_KEY, [
+			'interval' => 'hourly',
+		] );
+
+		$now          = new \DateTimeImmutable( '2020-09-17 12:15:00', wp_timezone() );
+		$current      = new \DateTimeImmutable( '2020-09-17 12:00:00', wp_timezone() );
+		$next         = new \DateTimeImmutable( '2020-09-17 13:00:00', wp_timezone() );
+		$placeholders = ( new OrderLimiter( $now ) )->get_placeholders();
+
+		$this->assertSame( $current->format( 'g:ia' ), $placeholders['{current_interval}'] );
+		$this->assertSame( $next->format( 'g:ia' ), $placeholders['{next_interval}'] );
 	}
 
 	/**

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -88,8 +88,7 @@ class SettingsTest extends TestCase {
 
 		$limiter = new OrderLimiter();
 		$limiter->init();
-
-		$this->generate_order();
+		$this->set_current_order_count( 1 );
 
 		$this->assertContains(
 			'<div class="notice notice-info">',
@@ -110,6 +109,7 @@ class SettingsTest extends TestCase {
 
 		$limiter = new OrderLimiter();
 		$limiter->init();
+		$this->set_current_order_count( 0 );
 
 		$this->assertNotContains(
 			'<div class="notice notice-info">',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@
 
 namespace Tests;
 
+use Nexcess\LimitOrders\OrderLimiter;
 use WC_Checkout;
 use WC_Helper_Product;
 use WP_UnitTestCase;
@@ -30,5 +31,14 @@ abstract class TestCase extends WP_UnitTestCase {
 			'billing_email'  => 'test_customer@example.com',
 			'payment_method' => 'dummy_payment_gateway',
 		] );
+	}
+
+	/**
+	 * Explicitly set the current interval's order count.
+	 *
+	 * @param int $orders The current number of orders.
+	 */
+	protected function set_current_order_count( $orders ) {
+		set_transient( OrderLimiter::TRANSIENT_NAME, (int) $orders );
 	}
 }


### PR DESCRIPTION
## Fixed

* Prevent the order count transient from being set before `$wc_order_types` is populated (#52)

## Changed

* Move the limiter initialization from "woocommerce_loaded" to "init" (#52)
* Change the format of the `{current_interval}` and `{next_interval}` placeholders if the interval is less than 24 hours (#53)